### PR TITLE
Allow two different type of users to sign up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,13 +26,13 @@ RUN node --version && npm --version
 COPY package.json /.project/package.json
 COPY package-lock.json /.project/package-lock.json
 RUN cd /.project && npm ci
-RUN mkdir -p /opt/app && cp -a /.project/. /opt/app/
+RUN mkdir -p /root/app && cp -a /.project/. /root/app/
 
-WORKDIR /opt/app
+WORKDIR /root/app
 
 RUN npm ci
 
-COPY . /opt/app
+COPY . /root/app
 
 # build arguments
 ARG APP_ENV

--- a/src/apps/backend/modules/account/types.py
+++ b/src/apps/backend/modules/account/types.py
@@ -16,6 +16,7 @@ class CreateAccountParams:
   last_name: str
   password: str
   username: str
+  customer_type: str
 
 
 @dataclass(frozen=True)

--- a/src/apps/frontend/constants/routes.ts
+++ b/src/apps/frontend/constants/routes.ts
@@ -4,7 +4,7 @@ const routes = {
   FORGOT_PASSWORD: '/forgot-password',
   LOGIN: '/login',
   RESET_PASSWORD: '/accounts/:accountId/reset_password',
-  SIGNUP: '/signup',
+  SIGNUP: '/:customer_type/signup',
   TASKS: '/tasks',
 };
 

--- a/src/apps/frontend/contexts/auth.provider.tsx
+++ b/src/apps/frontend/contexts/auth.provider.tsx
@@ -17,6 +17,7 @@ type AuthContextType = {
     firstName: string,
     lastName: string,
     username: string,
+    customer_type: string,
     password: string,
   ) => Promise<void>;
   signupError: AsyncError;
@@ -32,9 +33,10 @@ const signupFn = async (
   firstName: string,
   lastName: string,
   username: string,
+  customer_type: string,
   password: string,
 ): Promise<ApiResponse<void>> =>
-  authService.signup(firstName, lastName, username, password);
+  authService.signup(firstName, lastName, username, customer_type, password);
 
 const loginFn = async (
   username: string,

--- a/src/apps/frontend/pages/authentication/signup/signup-form.hook.ts
+++ b/src/apps/frontend/pages/authentication/signup/signup-form.hook.ts
@@ -1,5 +1,6 @@
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
+import { useParams } from 'react-router-dom';
 
 import constant from '../../../constants';
 import { useAuthContext } from '../../../contexts';
@@ -11,12 +12,14 @@ interface SignupFormProps {
 }
 const useSignupForm = ({ onError, onSuccess }: SignupFormProps) => {
   const { isSignupLoading, signupError, signup } = useAuthContext();
+  const { customer_type } = useParams();
 
   const formik = useFormik({
     initialValues: {
       firstName: '',
       lastName: '',
       username: '',
+      customer_type: customer_type,
       password: '',
       retypePassword: '',
     },
@@ -45,6 +48,7 @@ const useSignupForm = ({ onError, onSuccess }: SignupFormProps) => {
         values.firstName,
         values.lastName,
         values.username,
+        values.customer_type,
         values.password,
       )
         .then(() => {

--- a/src/apps/frontend/pages/login/login-form.tsx
+++ b/src/apps/frontend/pages/login/login-form.tsx
@@ -85,8 +85,11 @@ const LoginForm: React.FC<LoginFormProps> = ({ onError, onSuccess }) => {
         </Button>
         <p className="self-center font-medium">
           Don’t have any account?{' '}
-          <Link to={routes.SIGNUP} className="text-primary">
-            Sign Up
+          <Link to={'/care-givers/signup'} className="text-primary">
+            Sign Up Care Giver
+          </Link>
+          <Link to={'/families/signup'} className="text-primary">
+            Sign Up Family
           </Link>
         </p>
       </VerticalStackLayout>

--- a/src/apps/frontend/services/auth.service.ts
+++ b/src/apps/frontend/services/auth.service.ts
@@ -7,12 +7,14 @@ export default class AuthService extends APIService {
     firstName: string,
     lastName: string,
     username: string,
+    customer_type: string,
     password: string,
   ): Promise<ApiResponse<void>> =>
     this.apiClient.post('/accounts', {
       first_name: firstName,
       last_name: lastName,
       username: username,
+      customer_type: customer_type,
       password: password,
     });
 


### PR DESCRIPTION
## Description
_Allow two different type of users i.e care givers and families to sign up. Both type of signup have different routes. //care-givers/sign-up should show a sign up form with email and password. In backend, it should create an account with account type CARE_GIVER
//families/sign-up should allow a family to sign up with email and password. In backend, it should create an account with account type FAMILY
Made changes in DockerFile so that it can run in my local system_

## Database schema changes
_Added customer_type field in Accounts._

## Tests
### Automated test cases added
- _Description of automated test 1_
- _Description of automated test 2_
- _Description of automated test 3_

### Manual test cases run
_For each manual test case, list the steps to test or reproduce the PR._
- _Description of manual test 1_
- _Description of manual test 2_
- _Description of manual test 3_
